### PR TITLE
use default connection pool

### DIFF
--- a/flight/src/booking.ts
+++ b/flight/src/booking.ts
@@ -85,7 +85,10 @@ export async function initdb() {
         console.log(dbConfiged);
         // console.log(oracledb);
 
-        connection = await oracledb.getConnection(dbConfiged);
+        // create default connection pool
+        await oracledb.createPool(dbConfiged);
+
+        connection = await oracledb.getConnection(/*use connection pool*//*dbConfiged*/);
         // console.log(connection);
         
         await connection.execute(`begin
@@ -122,7 +125,7 @@ export class BookingService {
 
             let connection;
             try {
-                connection = await oracledb.getConnection(dbConfiged);
+                connection = await oracledb.getConnection(/*use connection pool*//*dbConfiged*/);
                 let result = await connection.execute<Booking>(`SELECT id as "id", encodedid as "encodedId" ,name as "name",status as "status",type as "type" FROM flight where id = '${bookingId}'`,{},{outFormat: oracledb.OUT_FORMAT_OBJECT});
                 console.log("Result is:", result);
                 return result.rows && Array.isArray(result.rows) ? result.rows[0] as Booking : null;
@@ -145,7 +148,7 @@ export class BookingService {
 
             let connection;
             try {
-                connection = await oracledb.getConnection(dbConfiged);
+                connection = await oracledb.getConnection(/*use connection pool*//*dbConfiged*/);
                 let result = await connection.execute<Booking>(`DELETE FROM flight where id = '${bookingId}'`);
                 await connection.commit();
                 console.log("deleteById Result is:", result);
@@ -168,7 +171,7 @@ export class BookingService {
 
             let connection;
             try {
-                connection = await oracledb.getConnection(dbConfiged);
+                connection = await oracledb.getConnection(/*use connection pool*//*dbConfiged*/);
                 let result = await connection.execute(`SELECT count(*) FROM flight where status = '`  + BookingStatus.CONFIRMED + `'` );
                 console.log("Result is:", result);
                 return result.rows && result.rows[0] && Array.isArray(result.rows[0]) ? result.rows[0][0] : 0;
@@ -190,7 +193,7 @@ export class BookingService {
 
             let connection;
             try {
-                connection = await oracledb.getConnection(dbConfiged);
+                connection = await oracledb.getConnection(/*use connection pool*//*dbConfiged*/);
                 let result = await connection.execute<Booking>(`SELECT id as "id", encodedid as "encodedId" ,name as "name",status as "status",type as "type" FROM flight`,[],{outFormat: oracledb.OUT_FORMAT_OBJECT});
                 console.log("Result is:", result);
                 return result.rows! as Booking[];
@@ -216,7 +219,7 @@ export class BookingService {
 
             let connection;
             try {
-                connection = await oracledb.getConnection(dbConfiged);
+                connection = await oracledb.getConnection(/*use connection pool*//*dbConfiged*/);
                 const sql =
                 'INSERT INTO flight (id, encodedid,name,status,type) VALUES (:id, :encodedid,:name,:status,:type )';
                 const binds = [booking.id, booking.encodedId,booking.name,booking.status,booking.type];
@@ -243,7 +246,7 @@ export class BookingService {
 
             let connection;
             try {
-                connection = await oracledb.getConnection(dbConfiged);
+                connection = await oracledb.getConnection(/*use connection pool*//*dbConfiged*/);
                 const sql =
                 'UPDATE flight set status = :status where id = :id';
                 const binds = [booking.status, booking.id];


### PR DESCRIPTION
It takes so long time for flight to get connection of  Oracle database every time, especially when using a wallet, and accordingly this causes request timeout of Helidon LRA module (10 sec) in complete/compensate phases. Connection pooling can dramatically improve the performance, needless to say. 

[without connection pool > timeout occurs]
![image_no_cp](https://user-images.githubusercontent.com/7146253/216133721-be3d7495-96c4-4492-9c25-8845f95f981b.png)

[with connection pool]
![image_cp](https://user-images.githubusercontent.com/7146253/216133796-9445b2af-0ab1-4e6f-ac29-456f754fc77b.png)
